### PR TITLE
New endpoint fix

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -75,6 +75,7 @@ class WargamingMetaTestCase(unittest.TestCase):
     ))
 
     @patch('wargaming.meta.ALLOWED_GAMES', ['demo'])
+    @patch('wargaming.meta.GAME_API_ENDPOINTS', {'demo': 'https://api.worldoftanks'})
     @patch('wargaming.meta.open', open_schema)
     def setUp(self):
 

--- a/wargaming/meta.py
+++ b/wargaming/meta.py
@@ -8,7 +8,12 @@ from bs4 import BeautifulSoup
 
 from wargaming.exceptions import RequestError, ValidationError
 from wargaming.settings import (
-    ALLOWED_GAMES, ALLOWED_REGIONS, HTTP_USER_AGENT_HEADER, RETRY_COUNT, REGION_API_ENDPOINTS
+    ALLOWED_GAMES,
+    ALLOWED_REGIONS,
+    HTTP_USER_AGENT_HEADER,
+    RETRY_COUNT,
+    GAME_API_ENDPOINTS,
+    REGION_API_EXT
 )
 
 
@@ -30,7 +35,10 @@ def region_url(region, game):
 
     # all api calls for all project goes to api.worldoftanks.*
     # maybe WG would move this api to api.wargaming.net
-    return '%s/%s/' % (REGION_API_ENDPOINTS[region], game)
+    return '%s.%s/%s/' % (
+            GAME_API_ENDPOINTS[game],
+            REGION_API_EXT[region],
+            game)
 
 
 @six.python_2_unicode_compatible

--- a/wargaming/settings.py
+++ b/wargaming/settings.py
@@ -2,14 +2,27 @@ from wargaming.version import get_version
 
 ALLOWED_GAMES = ('wot', 'wgn', 'wows', 'wotb', 'wotx', 'wowp')
 
-ALLOWED_REGIONS = ('ru', 'asia', 'na', 'eu', 'kr')
-REGION_API_ENDPOINTS = {
-    'ru': 'https://api.worldoftanks.ru',
-    'asia': 'https://api.worldoftanks.asia',
-    'na': 'https://api.worldoftanks.com',
-    'eu': 'https://api.worldoftanks.eu',
-    'kr': 'https://api.worldoftanks.kr',
+# WG classes xbox and ps4 as 'regions' hence they are incuded here
+ALLOWED_REGIONS = ('ru', 'asia', 'na', 'eu', 'kr', 'xbox', 'ps4')
+REGION_API_EXT = {
+    'ru': 'ru',
+    'asia': 'asia',
+    'na': 'com',
+    'eu': 'eu',
+    'kr': 'kr',
+    'ps4': 'com',
+    'xbox': 'com',
 }
+GAME_API_ENDPOINTS = {
+    'wgn': 'https://api.worldoftanks',
+    'wot': 'https://api.worldoftanks',
+    'wotb': 'https://api.wotblitz',
+    'wotx': 'https://api-xbox-console.worldoftanks',
+    'wotp': 'https://api-ps4-console.worldoftanks',
+    'wowp': 'https://api.worldofwarplanes',
+    'wows': 'https://api.worldofwarships',
+    }
+
 DEFAULT_REGION = 'ru'
 
 ALLOWED_LANGUAGES = ('en', 'ru', 'pl', 'de', 'fr', 'es', 'zh-cn', 'tr', 'cs', 'th', 'vi', 'ko')


### PR DESCRIPTION
Patch to fix python-wargaming to work with the new API endpoints. These are:
   
    'wgn': 'https://api.worldoftanks',
    'wot': 'https://api.worldoftanks',
    'wotb': 'https://api.wotblitz',
    'wotx': 'https://api-xbox-console.worldoftanks',
    'wotp': 'https://api-ps4-console.worldoftanks',
    'wowp': 'https://api.worldofwarplanes',
    'wows': 'https://api.worldofwarships'

and the BASE_URL is now built from the corresponding game url in `GAME_API_ENDPOINTS` and the region extension in `ALLOWED_REGIONS` defined in wargaming/settings.py

ps4 and xbox are defined in `ALLOWED_REGIONS` and both map to "com" for the console versions of WoT, as is the case with the wargaming API's.

However I have tested the API calls with these changes for World of Warships only. 